### PR TITLE
content: acorta los textos más largos

### DIFF
--- a/src/routes/(heading)/about-us/+page.svelte
+++ b/src/routes/(heading)/about-us/+page.svelte
@@ -16,12 +16,10 @@
 		<div class="col-span-2">
 			{@render subtitle("La Comunidad")}
 			<p class="mt-4 max-w-prose pl-7">
-				KOKOA es un club de software libre de ESPOL que fomenta la equidad, la colaboración y el
-				aprendizaje de software y tecnologías libres. Realizamos y colaboramos con múltiples
-				departamentos dentro y fuera de la ESPOL para desarrollar proyectos de índole académico y
-				profesional. Participamos en diferentes eventos a nivel local y nacional para la innovación
-				de tecnologías, elaboramos talleres y capacitaciones para ayudar a la comunidad en múltiples
-				necesidades académicas.
+				KOKOA es el club de software libre de ESPOL: fomentamos la equidad, la colaboración y el
+				aprendizaje de tecnologías libres. Junto a distintos departamentos dentro y fuera de la
+				ESPOL, desarrollamos proyectos, organizamos eventos y dictamos talleres para la comunidad
+				académica.
 			</p>
 		</div>
 		<div class="mt-6 sm:mt-0">
@@ -40,15 +38,10 @@
 		<div>
 			{@render subtitle("Historia")}
 			<p class="mt-4 pl-7">
-				Esta comunidad nació en el año de 1996, gracias a la ideología que tenían en común algunas
-				mentes politécnicas, que hasta la actualidad se desempeñan en áreas donde promueven el uso
-				de tecnologías libres. El club se ha consolidado como un espacio donde los miembros más
-				experimentados guían a los nuevos integrantes, compartiendo conocimientos sobre GNU/Linux,
-				distribuciones y desarrollo de software. No se requieren habilidades previas debido a que se
-				valora la curiosidad, la autodisciplina y el compromiso con el aprendizaje continuo. KOKOA
-				es una experiencia formativa, que comienza como un espacio de aprendizaje y se convierte en
-				una red de apoyo mutuo, donde cada miembro tiene la oportunidad de crecer, aprender y ser
-				parte de una comunidad inclusiva que trasciende los límites de ESPOL y se proyecta al mundo.
+				KOKOA nació en 1996 de la mano de un grupo de politécnicos que compartían una misma pasión
+				por el software libre. Hoy es un espacio donde los miembros con más experiencia guían a los
+				nuevos en GNU/Linux y desarrollo de software — no se requiere experiencia previa, solo
+				curiosidad y ganas de aprender.
 			</p>
 		</div>
 	</CenterContainer>

--- a/src/routes/(heading)/events/[id=number]/+page.svelte
+++ b/src/routes/(heading)/events/[id=number]/+page.svelte
@@ -60,30 +60,29 @@
 			{data.event.place}
 		</p>
 
-		{@render subtitle("¿Más información?")}
-		<p class="mt-2 font-fira">
-			Si quieres saber más sobre el evento, puedes seguir a los organizadores en sus redes sociales.
-			<br />
-		</p>
+		{#if data.event.web_url || data.event.instagram_url}
+			{@render subtitle("¿Más información?")}
+			<p class="mt-2 font-fira">Síguelos en sus redes:</p>
 
-		<div class="mt-6 flex flex-col gap-4">
-			{#if data.event.web_url}
-				<a class="flex gap-1 font-fira hover:underline" rel="external" href={data.event.web_url}>
-					<Globe class="size-6 text-kokoa-lime1" />
-					{data.event.web_page}
-				</a>
-			{/if}
+			<div class="mt-6 flex flex-col gap-4">
+				{#if data.event.web_url}
+					<a class="flex gap-1 font-fira hover:underline" rel="external" href={data.event.web_url}>
+						<Globe class="size-6 text-kokoa-lime1" />
+						{data.event.web_page}
+					</a>
+				{/if}
 
-			{#if data.event.instagram_url}
-				<a
-					class="flex gap-1 font-fira hover:underline"
-					rel="external"
-					href={data.event.instagram_url}
-				>
-					<img src={instagram} alt="Instagram" class="size-6" width="24" height="24" />
-					{data.event.instagram_username}
-				</a>
-			{/if}
-		</div>
+				{#if data.event.instagram_url}
+					<a
+						class="flex gap-1 font-fira hover:underline"
+						rel="external"
+						href={data.event.instagram_url}
+					>
+						<img src={instagram} alt="Instagram" class="size-6" width="24" height="24" />
+						{data.event.instagram_username}
+					</a>
+				{/if}
+			</div>
+		{/if}
 	</section>
 </CenterContainer>

--- a/src/routes/(heading)/join/+page.svelte
+++ b/src/routes/(heading)/join/+page.svelte
@@ -8,8 +8,8 @@
 	<!-- Texto encima del formulario -->
 	<div class="mb-6 text-center">
 		<p class="font-fira font-medium text-wrap">
-			Te estás inscribiendo al proceso de admisión correspondiente al 1PAO 2025, nos comunicaremos
-			contigo para darte a conocer las fechas y los siguientes pasos.
+			Te estás inscribiendo a nuestro proceso de admisión vigente. Te contactaremos pronto con las
+			fechas y los siguientes pasos.
 		</p>
 	</div>
 	<div class="w-full max-w-3xl" style="filter: invert(1) hue-rotate(180deg);">

--- a/src/routes/(heading)/projects/+page.svelte
+++ b/src/routes/(heading)/projects/+page.svelte
@@ -7,11 +7,8 @@
 
 <CenterContainer class="py-12">
 	<p class="font-fira font-medium">
-		Estos son algunos de los proyectos que hemos realizado en conjunto.
-	</p>
-	<p class="font-fira font-medium">
-		Nuestra meta es utlizar nuestras habilidades digitales para crear un impacto positivo en la
-		sociedad.
+		Estos son algunos de los proyectos que hemos realizado en conjunto, con la meta de usar nuestras
+		habilidades digitales para crear un impacto positivo en la sociedad.
 	</p>
 	<ul
 		role="list"


### PR DESCRIPTION
## Cambios
- **Nosotros:** se acortan «La Comunidad» (3 oraciones → 2) e «Historia» (5 oraciones, ~110 palabras → 2), que repetían la misma idea varias veces. **Chocomisión y Chocovisión quedan tal como estaban.**
- **Proyectos:** los dos párrafos de la intro se unen en uno y se corrige el typo «utlizar» → «utilizar».
- **Únete:** se acorta la intro y se reemplaza el «1PAO 2025» hardcodeado (ya desactualizado) por una redacción genérica, para no tener que editarlo cada período.
- **Detalle de evento:** la sección «¿Más información?» ahora solo aparece si el evento tiene web o Instagram — antes se renderizaba siempre, incluso cuando no había ningún link debajo — y su texto se acorta a «Síguelos en sus redes:».
