### PR TITLE
feat: anima el sitio con scroll-reveal y micro-interacciones

### DIFF
--- a/src/lib/actions/reveal.ts
+++ b/src/lib/actions/reveal.ts
@@ -1,0 +1,51 @@
+import type { Action } from "svelte/action";
+
+type RevealOptions = {
+	/** Retraso antes de animar, en ms — usado para escalonar listas. */
+	delay?: number;
+};
+
+/** Estado inicial oculto. Única fuente de verdad: el action remueve exactamente estas clases. */
+const HIDDEN = "translate-y-4 opacity-0";
+
+/**
+ * Clases que debe llevar todo elemento con `use:reveal`.
+ * Se anima `translate` (no `transform`): en Tailwind v4 `translate-y-*` usa la propiedad nativa.
+ */
+export const REVEAL_CLASS = `${HIDDEN} transition-[opacity,translate] duration-500 ease-out motion-reduce:transition-none`;
+
+const HIDDEN_CLASSES = HIDDEN.split(" ");
+
+/**
+ * Revela el elemento (fade + slide-up) la primera vez que entra en el viewport.
+ * Respeta prefers-reduced-motion mostrando el elemento sin animar.
+ */
+export const reveal: Action<HTMLElement, RevealOptions | undefined> = (node, options = {}) => {
+	const prefers_reduced_motion =
+		typeof matchMedia !== "undefined" && matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+	if (prefers_reduced_motion) {
+		node.classList.remove(...HIDDEN_CLASSES);
+		return {};
+	}
+
+	node.style.transitionDelay = `${options.delay ?? 0}ms`;
+
+	const observer = new IntersectionObserver(
+		(entries) => {
+			for (const entry of entries) {
+				if (!entry.isIntersecting) continue;
+				node.classList.remove(...HIDDEN_CLASSES);
+				observer.disconnect();
+			}
+		},
+		{ threshold: 0.15 },
+	);
+	observer.observe(node);
+
+	return {
+		destroy() {
+			observer.disconnect();
+		},
+	};
+};

--- a/src/lib/components/card.svelte
+++ b/src/lib/components/card.svelte
@@ -2,6 +2,8 @@
 	import { resolve } from "$app/paths";
 	import type { Pathname } from "$app/types";
 	import { MapPin } from "@lucide/svelte";
+	import { reveal, REVEAL_CLASS } from "$lib/actions/reveal.js";
+	import { CARD_LIFT_CLASS } from "$lib/styles.js";
 	import Tag from "./tag.svelte";
 
 	type Props = {
@@ -11,34 +13,32 @@
 		categories: string[];
 		description: string;
 		place?: string;
+		delay?: number;
 	};
 
-	let { route, date, name, categories, description, place }: Props = $props();
+	let { route, date, name, categories, description, place, delay = 0 }: Props = $props();
 </script>
 
-<li class="rounded-2xl bg-neutral-800 px-6 py-5">
-	<article class="flex h-full flex-col">
-		<span class="font-fira font-medium text-kokoa-lime1">{date}</span>
-		<h2 class="font-fira text-xl font-medium">{name}</h2>
-		<div class="mt-4 flex flex-wrap gap-2">
-			{#each categories as category (category)}
-				<Tag {category} />
-			{/each}
-		</div>
-		<p class="mt-4 flex-1">{description}</p>
-		<div class="mt-4 grid grid-flow-col items-center">
-			<div class="flex items-center gap-2">
-				{#if place}
+<li use:reveal={{ delay }} class={REVEAL_CLASS}>
+	<a
+		href={resolve(route)}
+		class="block h-full rounded-2xl bg-neutral-800 px-6 py-5 {CARD_LIFT_CLASS}"
+	>
+		<article class="flex h-full flex-col">
+			<span class="font-fira font-medium text-kokoa-lime1">{date}</span>
+			<h2 class="font-fira text-xl font-medium">{name}</h2>
+			<div class="mt-4 flex flex-wrap gap-2">
+				{#each categories as category (category)}
+					<Tag {category} />
+				{/each}
+			</div>
+			<p class="mt-4 flex-1">{description}</p>
+			{#if place}
+				<div class="mt-4 flex items-center gap-2">
 					<MapPin class="size-6" />
 					<span class="flex-1">{place}</span>
-				{/if}
-			</div>
-			<a
-				href={resolve(route)}
-				class="inline-block w-fit justify-self-end rounded-full bg-kokoa-lime1 px-3 py-1 text-sm font-semibold text-primary shadow-xs hover:bg-lime-400 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-kokoa-lime1"
-			>
-				Ver más
-			</a>
-		</div>
-	</article>
+				</div>
+			{/if}
+		</article>
+	</a>
 </li>

--- a/src/lib/components/member.svelte
+++ b/src/lib/components/member.svelte
@@ -3,6 +3,7 @@
 	import github from "$lib/assets/icons/github.svg";
 	import linkedin from "$lib/assets/icons/linkedin.svg";
 	import { Link } from "@lucide/svelte";
+	import { reveal, REVEAL_CLASS } from "$lib/actions/reveal.js";
 
 	type Props = {
 		member: {
@@ -14,8 +15,9 @@
 			slug: string;
 			social_media: { nombre: string; link: string }[];
 		};
+		delay?: number;
 	};
-	let { member }: Props = $props();
+	let { member, delay = 0 }: Props = $props();
 
 	const photos = import.meta.glob("$lib/assets/members/*", {
 		eager: true,
@@ -40,10 +42,10 @@
 	]);
 </script>
 
-<li class="text-center">
+<li use:reveal={{ delay }} class="text-center {REVEAL_CLASS}">
 	<div class="group relative mx-auto size-56 overflow-hidden rounded-full transition duration-150">
 		<img
-			class="size-56 object-cover transition duration-150 group-hover:brightness-30 group-hover:grayscale"
+			class="size-56 object-cover transition duration-150 group-hover:scale-105 group-hover:brightness-30 group-hover:grayscale"
 			src={get_photo(member.photo)}
 			width="224"
 			height="224"

--- a/src/lib/components/tag.svelte
+++ b/src/lib/components/tag.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <span
-	class="rounded-full border border-lime-500 bg-neutral-800 px-6 font-fira text-xs font-bold text-gray-50"
+	class="rounded-full border border-lime-500 bg-neutral-800 px-6 font-fira text-xs font-bold text-gray-50 transition-colors duration-150 hover:border-lime-300 hover:text-lime-300"
 >
 	{category}
 </span>

--- a/src/lib/styles.ts
+++ b/src/lib/styles.ts
@@ -1,0 +1,7 @@
+/**
+ * Elevación al pasar el mouse, compartida por las tarjetas clickeables
+ * (tarjetas de eventos/proyectos y el destacado de evento del inicio).
+ * Se anima `translate` (no `transform`): en Tailwind v4 `translate-y-*` usa la propiedad nativa.
+ */
+export const CARD_LIFT_CLASS =
+	"transition-[translate,box-shadow] duration-150 ease-out hover:-translate-y-1 hover:shadow-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-kokoa-lime1 motion-reduce:transition-none";

--- a/src/routes/(heading)/+layout.svelte
+++ b/src/routes/(heading)/+layout.svelte
@@ -1,8 +1,16 @@
 <script lang="ts">
+	import { onMount } from "svelte";
 	import { page } from "$app/state";
 	import CenterContainer from "$lib/components/center-container.svelte";
+	import { fly } from "svelte/transition";
 
 	let { children } = $props();
+
+	/** Arranca en false para que las barras decorativas entren animadas al montar. */
+	let mounted = $state(false);
+	onMount(() => {
+		mounted = true;
+	});
 </script>
 
 <div class="bg-linear-to-r/oklch from-kokoa-lime4 to-kokoa-lime3">
@@ -11,13 +19,36 @@
 			{page.data.title}
 			<span class="ml-auto w-24 sm:w-56"></span>
 		</h1>
-		<div class="absolute inset-y-0 right-10 w-5 bg-gray-950 sm:w-7"></div>
-		<div class="absolute inset-y-0 right-16 w-5 bg-gray-950 sm:right-19 sm:w-7"></div>
-		<div class="absolute inset-y-0 right-22 w-5 bg-gray-950 sm:right-28 sm:w-7"></div>
-		<div class="absolute inset-y-0 right-37 hidden w-7 bg-gray-950 sm:block"></div>
-		<div class="absolute inset-y-0 right-46 hidden w-7 bg-gray-950 sm:block"></div>
-		<div class="absolute inset-y-0 right-55 hidden w-7 bg-gray-950 sm:block"></div>
-		<div class="absolute inset-y-0 right-64 hidden w-7 bg-gray-950 sm:block"></div>
+		{#if mounted}
+			<div
+				class="absolute inset-y-0 right-10 w-5 bg-gray-950 sm:w-7"
+				in:fly={{ x: 30, duration: 300, delay: 0 }}
+			></div>
+			<div
+				class="absolute inset-y-0 right-16 w-5 bg-gray-950 sm:right-19 sm:w-7"
+				in:fly={{ x: 30, duration: 300, delay: 40 }}
+			></div>
+			<div
+				class="absolute inset-y-0 right-22 w-5 bg-gray-950 sm:right-28 sm:w-7"
+				in:fly={{ x: 30, duration: 300, delay: 80 }}
+			></div>
+			<div
+				class="absolute inset-y-0 right-37 hidden w-7 bg-gray-950 sm:block"
+				in:fly={{ x: 30, duration: 300, delay: 120 }}
+			></div>
+			<div
+				class="absolute inset-y-0 right-46 hidden w-7 bg-gray-950 sm:block"
+				in:fly={{ x: 30, duration: 300, delay: 160 }}
+			></div>
+			<div
+				class="absolute inset-y-0 right-55 hidden w-7 bg-gray-950 sm:block"
+				in:fly={{ x: 30, duration: 300, delay: 200 }}
+			></div>
+			<div
+				class="absolute inset-y-0 right-64 hidden w-7 bg-gray-950 sm:block"
+				in:fly={{ x: 30, duration: 300, delay: 240 }}
+			></div>
+		{/if}
 	</CenterContainer>
 </div>
 {@render children()}

--- a/src/routes/(heading)/about-us/+page.svelte
+++ b/src/routes/(heading)/about-us/+page.svelte
@@ -3,6 +3,7 @@
 <script lang="ts">
 	import CenterContainer from "$lib/components/center-container.svelte";
 	import gecko_text from "$lib/assets/logos/gecko-text.png";
+	import { reveal, REVEAL_CLASS } from "$lib/actions/reveal.js";
 </script>
 
 {#snippet subtitle(text: string)}
@@ -11,7 +12,7 @@
 	</h2>
 {/snippet}
 
-<section>
+<section use:reveal class={REVEAL_CLASS}>
 	<CenterContainer class="py-6 sm:grid sm:grid-cols-3 sm:items-center sm:gap-x-8 sm:py-10">
 		<div class="col-span-2">
 			{@render subtitle("La Comunidad")}
@@ -33,7 +34,7 @@
 		</div>
 	</CenterContainer>
 </section>
-<section>
+<section use:reveal={{ delay: 100 }} class={REVEAL_CLASS}>
 	<CenterContainer class="py-6">
 		<div>
 			{@render subtitle("Historia")}
@@ -46,7 +47,7 @@
 		</div>
 	</CenterContainer>
 </section>
-<section>
+<section use:reveal={{ delay: 200 }} class={REVEAL_CLASS}>
 	<CenterContainer class="py-6">
 		<div>
 			{@render subtitle("Chocomisión")}
@@ -58,7 +59,7 @@
 		</div>
 	</CenterContainer>
 </section>
-<section>
+<section use:reveal={{ delay: 300 }} class={REVEAL_CLASS}>
 	<CenterContainer class="py-6">
 		<div>
 			{@render subtitle("Chocovisión")}

--- a/src/routes/(heading)/events/+page.svelte
+++ b/src/routes/(heading)/events/+page.svelte
@@ -15,7 +15,7 @@
 		role="list"
 		class="mx-auto grid grid-cols-1 gap-x-8 gap-y-16 sm:grid-cols-2 lg:mx-0 lg:max-w-none lg:grid-cols-3"
 	>
-		{#each sorted_events as event (event.id)}
+		{#each sorted_events as event, i (event.id)}
 			<Card
 				route="/events/{event.id}"
 				date={event.date}
@@ -23,6 +23,7 @@
 				categories={event.categories}
 				description={event.description}
 				place={event.place}
+				delay={i * 60}
 			/>
 		{/each}
 	</ul>

--- a/src/routes/(heading)/members/+page.svelte
+++ b/src/routes/(heading)/members/+page.svelte
@@ -12,8 +12,8 @@
 			role="list"
 			class="mx-auto mt-10 grid grid-cols-1 gap-x-8 gap-y-16 sm:grid-cols-2 lg:mx-0 lg:max-w-none lg:grid-cols-4"
 		>
-			{#each data.members.filter((m) => m.directiva === "si") as member (member.photo)}
-				<Member {member} />
+			{#each data.members.filter((m) => m.directiva === "si") as member, i (member.photo)}
+				<Member {member} delay={i * 60} />
 			{/each}
 		</ul>
 	</section>
@@ -23,8 +23,8 @@
 			role="list"
 			class="mx-auto mt-10 grid grid-cols-1 gap-x-8 gap-y-16 sm:grid-cols-2 lg:mx-0 lg:max-w-none lg:grid-cols-3"
 		>
-			{#each data.members.filter((m) => m.directiva === "no") as member (member.photo)}
-				<Member {member} />
+			{#each data.members.filter((m) => m.directiva === "no") as member, i (member.photo)}
+				<Member {member} delay={i * 60} />
 			{/each}
 		</ul>
 	</section>

--- a/src/routes/(heading)/projects/+page.svelte
+++ b/src/routes/(heading)/projects/+page.svelte
@@ -14,13 +14,14 @@
 		role="list"
 		class="mx-auto mt-12 grid grid-cols-1 gap-x-8 gap-y-16 sm:grid-cols-2 lg:mx-0 lg:max-w-none lg:grid-cols-3"
 	>
-		{#each data.projects as project (project.id)}
+		{#each data.projects as project, i (project.id)}
 			<Card
 				route="/projects/{project.id}"
 				date={project.term}
 				name={project.name}
 				categories={project.categories}
 				description={project.description}
+				delay={i * 60}
 			/>
 		{/each}
 	</ul>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,6 +3,7 @@
 	import { page } from "$app/state";
 	import Footer from "$lib/components/layout/footer.svelte";
 	import Navbar from "$lib/components/layout/navbar.svelte";
+	import { fade } from "svelte/transition";
 
 	let { children } = $props();
 </script>
@@ -14,6 +15,10 @@
 
 <Navbar />
 <main class="flex-1">
-	{@render children()}
+	{#key page.url.pathname}
+		<div in:fade={{ duration: 150 }}>
+			{@render children()}
+		</div>
+	{/key}
 </main>
 <Footer />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,6 +5,7 @@
 	import { Bot, Cpu, SquareCode, SquareTerminal } from "@lucide/svelte";
 	import Chocoevento from "./chocoevento.svelte";
 	import Member from "$lib/components/member.svelte";
+	import { reveal, REVEAL_CLASS } from "$lib/actions/reveal.js";
 
 	let { data } = $props();
 	let active_events = $derived(data.events.filter((event) => event.active === "true"));
@@ -17,7 +18,7 @@
 {/snippet}
 
 <Hero />
-<section>
+<section use:reveal class={REVEAL_CLASS}>
 	<CenterContainer class="py-6 sm:py-10">
 		{@render subtitle("Chocoáreas")}
 		<div class="md:grid md:grid-cols-4 md:gap-x-10">
@@ -46,7 +47,7 @@
 		<div class="mt-16 flex justify-center">
 			<a
 				href={resolve("/projects")}
-				class="inline-block rounded-full bg-lime-500 px-14 py-2 font-fira text-base font-semibold text-gray-900 shadow-xs hover:bg-lime-400 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-lime-500"
+				class="inline-block rounded-full bg-lime-500 px-14 py-2 font-fira text-base font-semibold text-gray-900 shadow-xs transition-colors duration-150 hover:bg-lime-400 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-lime-500"
 			>
 				Ver proyectos
 			</a>
@@ -54,7 +55,7 @@
 	</CenterContainer>
 </section>
 
-<section>
+<section use:reveal class={REVEAL_CLASS}>
 	<CenterContainer class="py-6 sm:py-10">
 		{@render subtitle("Chocoeventos")}
 
@@ -62,14 +63,14 @@
 			<p class="mt-6 text-center text-xl text-gray-400">No hay eventos activos en este momento.</p>
 		{:else}
 			<div class="mt-6 flex flex-col gap-y-6">
-				{#each active_events as event (event.id)}
-					<Chocoevento {event} />
+				{#each active_events as event, i (event.id)}
+					<Chocoevento {event} delay={i * 60} />
 				{/each}
 			</div>
 			<div class="mt-6 flex justify-center">
 				<a
 					href={resolve("/events")}
-					class="inline-block rounded-full bg-kokoa-lime1 px-14 py-2 font-fira text-base font-semibold text-gray-900 shadow-xs hover:bg-lime-400 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-lime-500"
+					class="inline-block rounded-full bg-kokoa-lime1 px-14 py-2 font-fira text-base font-semibold text-gray-900 shadow-xs transition-colors duration-150 hover:bg-lime-400 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-lime-500"
 				>
 					Ver todos los eventos
 				</a>
@@ -77,21 +78,21 @@
 		{/if}
 	</CenterContainer>
 </section>
-<section>
+<section use:reveal class={REVEAL_CLASS}>
 	<CenterContainer class="py-6 sm:py-10">
 		{@render subtitle("Chocomiembros")}
 		<ul
 			role="list"
 			class="mx-auto mt-16 grid grid-cols-1 gap-x-8 gap-y-16 sm:grid-cols-2 lg:mx-0 lg:max-w-none lg:grid-cols-4"
 		>
-			{#each data.members.filter((m) => m.directiva === "si") as member (member.photo)}
-				<Member {member} />
+			{#each data.members.filter((m) => m.directiva === "si") as member, i (member.photo)}
+				<Member {member} delay={i * 60} />
 			{/each}
 		</ul>
 		<div class="mt-16 flex justify-center">
 			<a
 				href={resolve("/members")}
-				class="inline-block rounded-full bg-lime-500 px-14 py-2 font-fira text-base font-semibold text-gray-900 shadow-xs hover:bg-lime-400 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-lime-500"
+				class="inline-block rounded-full bg-lime-500 px-14 py-2 font-fira text-base font-semibold text-gray-900 shadow-xs transition-colors duration-150 hover:bg-lime-400 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-lime-500"
 			>
 				Ver miembros
 			</a>

--- a/src/routes/chocoevento.svelte
+++ b/src/routes/chocoevento.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { resolve } from "$app/paths";
 	import { CalendarDays, Clock3, MapPin, MoveRight } from "@lucide/svelte";
+	import { reveal, REVEAL_CLASS } from "$lib/actions/reveal.js";
+	import { CARD_LIFT_CLASS } from "$lib/styles.js";
 
 	type Props = {
 		event: {
@@ -14,51 +16,59 @@
 			// active: string;
 			image: string;
 		};
+		delay?: number;
 	};
-	let { event }: Props = $props();
+	let { event, delay = 0 }: Props = $props();
 </script>
 
-<article class="overflow-hidden rounded-3xl border border-kokoa-lime1 bg-primary">
-	<div
-		class="grid gap-6 p-6 sm:grid-cols-[minmax(0px,2fr)_minmax(0px,1fr)] md:grid-cols-[minmax(0px,1fr)_minmax(0px,2fr)_minmax(0px,1fr)]"
+<div use:reveal={{ delay }} class={REVEAL_CLASS}>
+	<a
+		href={resolve(`/events/${event.id}`)}
+		class="group block overflow-hidden rounded-3xl border border-kokoa-lime1 bg-primary {CARD_LIFT_CLASS}"
 	>
-		<img
-			class="h-32 w-full rounded-3xl object-cover object-center sm:col-span-2 md:col-span-1"
-			src={event.image}
-			alt="Imagen de evento"
-		/>
-		<div class="max-w-prose">
-			<h3 class="font-fira text-2xl font-semibold">{event.name}</h3>
-			<p class="mt-2">{event.description}</p>
+		<div
+			class="grid gap-6 p-6 sm:grid-cols-[minmax(0px,2fr)_minmax(0px,1fr)] md:grid-cols-[minmax(0px,1fr)_minmax(0px,2fr)_minmax(0px,1fr)]"
+		>
+			<img
+				class="h-32 w-full rounded-3xl object-cover object-center sm:col-span-2 md:col-span-1"
+				src={event.image}
+				alt="Imagen de evento"
+			/>
+			<div class="max-w-prose">
+				<h3 class="font-fira text-2xl font-semibold">{event.name}</h3>
+				<p class="mt-2">{event.description}</p>
+			</div>
+			<dl class="flex flex-col gap-y-2">
+				<div class="grid grid-cols-[24px_minmax(0px,1fr)] items-center gap-x-3 text-kokoa-lime1">
+					<dt>
+						<span class="sr-only">Fecha</span>
+						<CalendarDays class="size-6" aria-hidden="true" />
+					</dt>
+					<dd class="text-lg">{event.date}</dd>
+				</div>
+				<div class="grid grid-cols-[24px_minmax(0px,1fr)] items-center gap-x-3">
+					<dt>
+						<span class="sr-only">Hora</span>
+						<Clock3 class="size-6" aria-hidden="true" />
+					</dt>
+					<dd>{event.time}</dd>
+				</div>
+				<div class="grid grid-cols-[24px_minmax(0px,1fr)] items-center gap-x-3">
+					<dt>
+						<span class="sr-only">Lugar</span>
+						<MapPin class="size-6" aria-hidden="true" />
+					</dt>
+					<dd>{event.place}</dd>
+				</div>
+			</dl>
 		</div>
-		<dl class="flex flex-col gap-y-2">
-			<div class="grid grid-cols-[24px_minmax(0px,1fr)] items-center gap-x-3 text-kokoa-lime1">
-				<dt>
-					<span class="sr-only">Fecha</span>
-					<CalendarDays class="size-6" aria-hidden="true" />
-				</dt>
-				<dd class="text-lg">{event.date}</dd>
-			</div>
-			<div class="grid grid-cols-[24px_minmax(0px,1fr)] items-center gap-x-3">
-				<dt>
-					<span class="sr-only">Hora</span>
-					<Clock3 class="size-6" aria-hidden="true" />
-				</dt>
-				<dd>{event.time}</dd>
-			</div>
-			<div class="grid grid-cols-[24px_minmax(0px,1fr)] items-center gap-x-3">
-				<dt>
-					<span class="sr-only">Lugar</span>
-					<MapPin class="size-6" aria-hidden="true" />
-				</dt>
-				<dd>{event.place}</dd>
-			</div>
-		</dl>
-	</div>
-	<div class="flex justify-end bg-kokoa-lime1 px-6 py-2 font-fira font-semibold text-primary">
-		<a href={resolve(`/events/${event.id}`)} class="flex items-center gap-2 gap-x-3">
-			<span>Información</span>
-			<MoveRight />
-		</a>
-	</div>
-</article>
+		<div class="flex justify-end bg-kokoa-lime1 px-6 py-2 font-fira font-semibold text-primary">
+			<span
+				class="flex items-center gap-2 gap-x-3 transition-transform duration-150 group-hover:translate-x-1"
+			>
+				<span>Información</span>
+				<MoveRight />
+			</span>
+		</div>
+	</a>
+</div>

--- a/src/routes/hero.svelte
+++ b/src/routes/hero.svelte
@@ -4,13 +4,14 @@
 	import { resolve } from "$app/paths";
 	import CenterContainer from "$lib/components/center-container.svelte";
 	import feria from "$lib/assets/images/portada.jpg";
+	import { reveal, REVEAL_CLASS } from "$lib/actions/reveal.js";
 </script>
 
 <CenterContainer
 	tag="section"
 	class="flex flex-col items-center justify-between gap-8 py-10 md:flex-row"
 >
-	<div class="max-w-xs md:max-w-none md:flex-[2_2_0%]">
+	<div use:reveal class="max-w-xs md:max-w-none md:flex-[2_2_0%] {REVEAL_CLASS}">
 		<div class="relative mx-auto w-4/5">
 			<div class="absolute -top-5 -left-5 size-24 bg-kokoa-lime1"></div>
 			<div class="absolute -right-5 -bottom-5 size-24 border border-kokoa-lime1"></div>
@@ -23,7 +24,10 @@
 			/>
 		</div>
 	</div>
-	<div class="flex flex-col items-center gap-y-5 text-center md:flex-[3_3_0%]">
+	<div
+		use:reveal={{ delay: 150 }}
+		class="flex flex-col items-center gap-y-5 text-center md:flex-[3_3_0%] {REVEAL_CLASS}"
+	>
 		<h1 class="font-fira text-lg font-bold lg:text-2xl">
 			<span class="text-kokoa-lime2">Kokoa</span>
 			<span class="text-blue-100">- Vive el software libre</span>
@@ -34,7 +38,7 @@
 		</p>
 		<a
 			href={resolve("/join")}
-			class="inline-block rounded-full bg-lime-500 px-14 py-2 text-base font-semibold text-gray-900 shadow-xs hover:bg-lime-400 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-lime-500"
+			class="inline-block rounded-full bg-lime-500 px-14 py-2 text-base font-semibold text-gray-900 shadow-xs transition-colors duration-150 hover:bg-lime-400 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-lime-500"
 		>
 			Unirse
 		</a>


### PR DESCRIPTION
## Cambios
Sin dependencias nuevas: solo utilidades de Tailwind, `svelte/transition` y un `IntersectionObserver`, en la misma línea que el indicador del navbar.

- **Scroll-reveal:** nuevo action `use:reveal` que hace aparecer los elementos (fade + slide-up) al entrar en pantalla, escalonado en las grillas de eventos, proyectos y miembros. Respeta `prefers-reduced-motion`.
- **Tarjetas clickeables:** toda la tarjeta de evento/proyecto es un link (antes solo el botón «Ver más», que se elimina), con una elevación breve al pasar el mouse.
- **Micro-interacciones:** transición de color en los botones que antes cambiaban de golpe, hover en los tags, zoom leve en la foto de miembro y flecha que se desplaza en el destacado de eventos.
- **Banner:** las barras decorativas entran deslizándose en cascada al cargar la página.
- **Navegación:** fade corto entre rutas en vez del cambio instantáneo.

